### PR TITLE
修复(Fix): 统一日期格式为UTC以解决跨时区问题

### DIFF
--- a/src/view/Edit/Edit.vue
+++ b/src/view/Edit/Edit.vue
@@ -729,7 +729,7 @@ function saveDiary() {
         weather: diary.value.weather,
         is_public: diary.value.is_public ? 1 : 0,
         is_markdown: diary.value.is_markdown ? 1 : 0,
-        date: dateFormatter(diary.value.date),
+        date: new Date(diary.value.date).toISOString(),//date: dateFormatter(diary.value.date),
     }
     if (isNew.value){
         diaryApi


### PR DESCRIPTION
### 问题描述 (Problem Description)

当前，在保存日记时，前端向后端发送的是一个不包含时区信息的本地时间字符串。当用户和服务器处于不同时区时，这会导致后端错误地解析时间，最终在前端页面上显示出一个与用户本地时间不符的、有偏差的时间。

### 解决方案 (Solution)

本次修改将前端发送 `date` 字段的方式，从一个本地时间字符串 (例如 `YYYY-MM-DD HH:mm:ss`) 更改为发送**标准的、包含 UTC 信息的 ISO 8601 格式字符串** (通过 `new Date().toISOString()`)。

在前后端分离、跨时区部署的场景下，强制数据库连接使用 UTC (`"Z"`) 模式，服务器配置文件configDatabase.json 
{
    "host": "localhost",
    "user": "username",
    "password": "password",
    "port": 3306,
    "multipleStatements": true,
    "timezone": "Z"
}
是解决时间不一致问题的最佳实践。当配合一个发送标准 UTC 时间的前端时，这个配置可以确保数据库正确地处理和存储时间。

这个改动确保了无论用户在哪个时区操作，发送到后端的时间都经过了统一的 UTC 标准化处理，从根本上解决了跨时区部署时的时间不一致问题。